### PR TITLE
Fix issues on reset and forgot password pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4099,6 +4099,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@schematics/angular": {
       "version": "16.0.6",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.0.6.tgz",

--- a/src/app/public/components/auth-page/auth-page.component.ts
+++ b/src/app/public/components/auth-page/auth-page.component.ts
@@ -23,6 +23,9 @@ export class AuthPageComponent implements OnInit, OnDestroy {
   private subscriptions = new Subscription();
   private currentRoute = '';
   public runFunction!: Function;
+  private config: MatSnackBarConfig = {
+    duration: 5 * 1000,
+  };
 
   functionMap: { [key: string]: Function } = {
     login: (param: any) => this.login(param),
@@ -196,12 +199,15 @@ export class AuthPageComponent implements OnInit, OnDestroy {
     this.authService.forgotPassword(formData?.email as string).subscribe({
       next: (res:IAPIResponse) => {
         if(res.Status === APIStatusMessage.Success){
-          const config: MatSnackBarConfig = {
-            duration: 5 * 1000,
-          };
-          this._snackBar.open(res.Message,'',config);
+          this._snackBar.open(res.Message,'',this.config);
           console.log(res.Message)
           this.router.navigateByUrl('/auth/login')
+        }
+      },
+      error: (errResponse) => {
+        const error = errResponse.error;
+        if(error.Code === 404){
+          this._snackBar.open(error.Message,'',this.config)
         }
       }
     });

--- a/src/app/public/components/auth-page/reset-password/reset-password.component.ts
+++ b/src/app/public/components/auth-page/reset-password/reset-password.component.ts
@@ -55,8 +55,9 @@ export class ResetPasswordComponent implements OnInit, OnDestroy {
                 duration: 5 * 1000,
               };
               this._snackBar.open("Passwords did not match",'',config);
+            }else{
+              this.resetPassword(res.password);
             }
-            this.resetPassword(res.password);
           }
         },
       })
@@ -69,13 +70,13 @@ export class ResetPasswordComponent implements OnInit, OnDestroy {
         controlLabel: 'Password',
         controlName: 'password',
         controlType: 'password',
-        controlValidation: { required: true },
+        controlValidation: { required: true, newPassword: true },
       },
       {
         controlLabel: 'Re-Password',
         controlName: 'reEnterPassword',
         controlType: 'password',
-        controlValidation: { required: true },
+        controlValidation: { required: true, newPassword: true },
       },
     ];
   }
@@ -103,6 +104,9 @@ export class ResetPasswordComponent implements OnInit, OnDestroy {
           this.router.navigateByUrl('/auth/login');
         }
       },
+      error: (err) => {
+        console.log(err)
+      } 
     });
   }
 


### PR DESCRIPTION
Issues fixed:
1. If a user is not registered, Proper message to be displayed on the screen - Done
2. Reset password : if the new password and confirm password doesnot match - Done
    1. Password is still getting updated to new password
    2. User is logged in

Cause:
1. Proper notification is missing.
2. Was missing a else condition when we were checking the two passwords. Noob mistake.