### PR TITLE
Fix search screen issues

### DIFF
--- a/src/app/private/services/private-common.service.ts
+++ b/src/app/private/services/private-common.service.ts
@@ -39,7 +39,7 @@ export class PrivateCommonService {
   ): Observable<ITask> {
     let newTask: ITaskCreate = {
       userId: this.UserId,
-      currentListId: task.currentListId,
+      currentListId: task.currentListId ? task.currentListId : '0',
       previousListID: '0',
       taskTitle: task.taskTitle,
       taskDesc: task.taskDesc,


### PR DESCRIPTION
Issue: There was some issue while creating/updating or deleting a task in the search screen.

Cause: This was because of the currentListId getting undefined.

Fix: Type checked it to assign appropriate values to the currentListId.